### PR TITLE
Fixed: RSS entries detection bug

### DIFF
--- a/src/detect_rss_entry/RSSEntryDetector.py
+++ b/src/detect_rss_entry/RSSEntryDetector.py
@@ -94,10 +94,10 @@ class RelatedRSSEntryDetector:
 
     def matched_keyword(self, entry: RSSEntry, selector: str, keywords: List[str]) -> Optional[str]:
         for k in keywords:
-            if re.match(k, entry.title):
+            if re.findall(k, entry.title):
                 return k
         text = self._driver.find_element(entry.url, selector).selected_text
         for k in keywords:
-            if re.match(k, text):
+            if re.findall(k, text):
                 return k
         return None


### PR DESCRIPTION
see: re — Regular expression operations — Python 3.7.4 documentation
https://docs.python.org/3/library/re.html#re.match

```
re.match(pattern, string, flags=0)
If zero or more characters at the beginning of string match the regular expression pattern, return a corresponding match object. Return None if the string does not match the pattern; note that this is different from a zero-length match.

Note that even in MULTILINE mode, re.match() will only match at the beginning of the string and not at the beginning of each line.
```